### PR TITLE
feat(CI): github chat bot add obs webhook resend support

### DIFF
--- a/.github/workflows/chatOps.yml
+++ b/.github/workflows/chatOps.yml
@@ -110,14 +110,17 @@ jobs:
                 await github.request(`POST /repos/${context.repo.owner}/${context.repo.repo}/actions/jobs/${run.id}/rerun`);
               }
             }
-      # auto merge pull request
+
       - name: install depends for load scripts
-        if: startsWith(github.event.comment.body, '/merge')
+        if: |
+          startsWith(github.event.comment.body, '/merge') || startsWith(github.event.comment.body, '/check')
         run: |
           npm install @octokit/rest
           npm install @octokit/auth-app
+
       - name: Get token using github-script
-        if: startsWith(github.event.comment.body, '/merge')
+        if: |
+          startsWith(github.event.comment.body, '/merge') || startsWith(github.event.comment.body, '/check')
         id: get-token
         uses: actions/github-script@v6
         with:
@@ -140,6 +143,108 @@ jobs:
               installationId: app_installation.data.id
             });
             core.setOutput('app_token', token)
+
+      # retrigger obs build webhook
+      - name: check obs
+        uses: actions/github-script@v6
+        if: startsWith(github.event.comment.body, '/check')
+        id: check-obs
+        env:
+          COMMENT_BODY: ${{ github.event.comment.body }}
+          HOOK_ID: 396506100
+        with:
+          github-token: ${{ steps.get-token.outputs.app_token }}
+          script: |
+            const { COMMENT_BODY } = process.env
+            const checkNameGroup = COMMENT_BODY.match(/\/check (\S+)/)
+
+            // handle obs workflow resend
+            obs_webhook_need_resend = true
+
+            if (checkNameGroup && !COMMENT_BODY.includes("obs")) {
+              obs_webhook_need_resend = false
+            }
+
+            // console.log("HOOK_ID: ", process.env.HOOK_ID)
+            if (obs_webhook_need_resend) {
+              // deliveries obs webhook
+              let maxWebhooks = 1000
+              let since = 0
+              let retriggered = false
+              for await (const WebhookDeliveriesResp of github.paginate.iterator(
+                github.rest.orgs.listWebhookDeliveries,
+                {
+                  org: context.repo.owner,
+                  hook_id: process.env.HOOK_ID,
+                  per_page: 100,
+                },
+                (response, done) => {
+                  since += response.data.length;
+                  // 最大1000条webhook中查找
+                  if (retriggered || since >= maxWebhooks) {
+                    done();
+                  }
+                  return response.data;
+                }
+              )) {
+                console.log("github repository_id: ", ${{ github.repository_id }})
+                core.setOutput('retriggered', "false")
+                for (var i = 0; i < WebhookDeliveriesResp.data.length; i++) {
+                  let wh = WebhookDeliveriesResp.data[i]
+                  // console.log("webhook event: ", wh.event, ", webhook repository_id: ", wh.repository_id)
+                  if (wh.event == 'pull_request' && wh.repository_id == ${{ github.repository_id }}) {
+                    const resp = await github.rest.orgs.redeliverWebhookDelivery({
+                      org: context.repo.owner,
+                      hook_id: process.env.HOOK_ID,
+                      delivery_id: wh.id,
+                    });
+                    console.log("redeliver webhook resp: ", resp)
+                    retriggered = true
+                    core.setOutput('retriggered', "true")
+                    return
+                  }
+                }
+              }
+            }
+
+
+      - name: check obs comment
+        uses: actions/github-script@v6
+        if: ${{ steps.check-obs.outputs.retriggered }} == "false"
+        with:
+          github-token: ${{ steps.get-token.outputs.app_token }}
+          script: |
+            console.log("redeliveried failed, context.issue.number: ", context.issue.number)
+            const BOT_NAME = "Deepin ChatGPT Bot"
+            const COMMENT_HEAD = "**" + BOT_NAME + "**\n"
+            let COMMENT_BODY = "Deepin redeliveried failed, need update or recreate pull request!!!"
+
+            if ( context.issue.number != undefined ) {
+              const response = await github.rest.issues.listComments({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number
+              })
+              const reg = new RegExp("\\*+" + BOT_NAME + "\\*+")
+              BotComment= response.data.find(comment => comment.body.match(reg))
+              if (BotComment) {
+                await github.rest.issues.updateComment({
+                    comment_id: BotComment.id,
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    body: COMMENT_HEAD + COMMENT_BODY
+                })
+              } else {
+                await github.rest.issues.createComment({
+                    issue_number: context.issue.number,
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    body: COMMENT_HEAD + COMMENT_BODY
+                })
+              }
+            }
+
+      # auto merge pull request
       - name: merge
         uses: actions/github-script@v5
         if: startsWith(github.event.comment.body, '/merge')


### PR DESCRIPTION
'/check' or '/check obs' pr comment will trigger webhook resend.

由于用于obs构建的github webhook是基于组织的(linuxdeepin/deepin-community),因此 在进行resend操作之前要进行webhook事件过滤,过滤范围为最近的1000条事件,超过这个范围 的事件应该是无法被resend的

log: