### PR TITLE
fix(CI): /integrate get incorrect commit id when pr merged

### DIFF
--- a/.github/workflows/chatOps.yml
+++ b/.github/workflows/chatOps.yml
@@ -314,8 +314,11 @@ jobs:
                 repo: context.repo.repo,
                 pull_number: context.issue.number
             });
-
-            core.setOutput('ref', response.data.head.sha)
+            if (response.data.state != "closed") {
+              core.setOutput('ref', response.data.head.sha)
+            } else {
+              core.setOutput('ref', response.data.merge_commit_sha)
+            }
 
   integration:
     needs:


### PR DESCRIPTION
pr merged use 'merge_commit_sha' as integrate sha

log: